### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/Barch/Adaptors.hs
+++ b/Barch/Adaptors.hs
@@ -61,5 +61,5 @@ parseBibUrl::(Text, Text)->Either (Text, Text) (Text, Html)
 parseBibUrl (key, val) = case (T.toLower key) of
   "url" -> Right $ (key, [shamlet|<a href="#{val}">#{val}</a>|])
 --  "eprint" -> Right $ (key, [shamlet|<a href="#{val}">#{val}</a>|])
-  "doi" -> Right $ (key, [shamlet|<a href="http://dx.doi.org/#{val}">#{val}</a>|])
+  "doi" -> Right $ (key, [shamlet|<a href="https://doi.org/#{val}">#{val}</a>|])
   _ -> Left (key, val)


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). It may be a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old `dx` subdomain is being redirected, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to the code that generates new DOI links.

Cheers!